### PR TITLE
 ENH: Add support for projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,5 +48,5 @@ The main entry point into Kepler is the ``kepler.ModelInspector`` class. It is a
    >>> from sklearn.datasets import load_digits
    >>> digits = load_digits()
    >>> X, y = digits['data'], digits['target']
-   >>> with ModelInspector(model=mnist_shallow) as mi:
+   >>> with ModelInspector(model=mnist_shallow()) as mi:
    ...      mi.fit(X, y)

--- a/kepler/main.py
+++ b/kepler/main.py
@@ -201,7 +201,7 @@ class ModelInspector(HasTraits):
         self.write_model_config()
         if self.enable_model_search:
             if self.config.get('models', 'enable_model_search'):
-                x = model_representation(self.model)
+                x = model_representation(self.model, self.model_vectorizer)
                 self.search(x)
         self.run_model_checks()
         self.model_proxy = ModelProxy(self.model, self, self.checks)
@@ -245,7 +245,7 @@ class ModelInspector(HasTraits):
             Whether to prompt the user if similar models are found.
         """
         if x is None:
-            x = model_representation(self.model)
+            x = model_representation(self.model, self.model_vectorizer)
         X = load_model_arch_mat(self.config.get('models', 'model_archs'))
         if X is None:  # nothing to search against
             return

--- a/kepler/sample_models.py
+++ b/kepler/sample_models.py
@@ -1,0 +1,33 @@
+"""Module for loading sample models."""
+
+from keras.models import Sequential
+from keras import layers as L
+from keras.optimizers import SGD
+
+
+def mnist_shallow(compile=True):
+    """Load a shallow model meant for the sklearn MNIST dataset.
+
+    Parameters
+    ----------
+        compile : bool, optional
+            If true (default), the model is compiled.
+
+    Returns
+    -------
+    keras model
+
+    Example
+    -------
+
+    """
+    model = Sequential([
+        L.Dense(32, input_shape=(64,)),
+        L.Activation('sigmoid'),
+        L.Dense(10),
+        L.Activation('sigmoid')
+    ])
+    if compile:
+        model.compile(optimizer=SGD(lr=0.05), loss='categorical_crossentropy',
+                      metrics=['accuracy'])
+    return model

--- a/kepler/tests/test_main.py
+++ b/kepler/tests/test_main.py
@@ -1,0 +1,50 @@
+"""Test the kepler.main module."""
+
+import os
+
+from keras.utils import to_categorical
+from sklearn.datasets import load_digits
+from sqlalchemy.orm import sessionmaker
+
+from kepler.tests import TestKepler
+from kepler.sample_models import mnist_shallow
+from kepler import ModelInspector
+from kepler.utils import get_engine
+import kepler.db_models as db
+
+
+class TestMain(TestKepler):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestMain, cls).setUpClass()
+        cls.engine = get_engine(cls.config.get('default', 'db'))
+
+    def setUp(self):
+        self.session = sessionmaker(self.engine)()
+
+    def tearDown(self):
+        self.session.close()
+
+    def test_add_project(self):
+        """Test if adding a project works."""
+        db.add_project(self.engine, 'test_project')
+        res = self.session.query(db.Project).filter(db.Project.name == 'test_project').all()
+        self.assertEqual(len(res), 1)
+        res = res[0]
+        self.assertEqual(res.name, 'test_project')
+        self.assertEqual(res.location, os.getcwd())
+        self.assertEqual(res.desc, '')
+
+    def test_default_project(self):
+        """Check if an arbitrary model appears in the default project."""
+        model = mnist_shallow()
+        digits = load_digits()
+        X = digits['data']
+        y = digits['target']
+        y = to_categorical(y)
+        with ModelInspector(model=model, config=self.config) as mi:
+            mi.fit(X, y)
+        res = self.session.query(db.ProjectModel).all()[0]
+        self.assertEqual(res.project.name, 'default')
+        self.assertEqual(res.model.name, 'Sequential-4-layers')

--- a/kepler/tests/test_utils.py
+++ b/kepler/tests/test_utils.py
@@ -44,7 +44,9 @@ class TestUtils(TestKepler):
 
     def test_initdb(self):
         # Check if initdb works.
-        self.ideal_tables = {'metadata', 'models', 'experiments', 'history'}
+        self.ideal_tables = {
+            'metadata', 'models', 'experiments',
+            'history', 'projects', 'projectmodels'}
         with NamedTemporaryFile() as ntf:
             utils.initdb(ntf.name)
             with connect(ntf.name) as conn:

--- a/kepler/tests/test_utils.py
+++ b/kepler/tests/test_utils.py
@@ -60,7 +60,6 @@ class TestUtils(TestKepler):
 
     def test_model_vectorizer(self):
         # Test if the vectorizer functions work.
-        # Caution: This doesn't test cases where input paths are None.
         ideal_layers = utils.get_keras_layers()
         with NamedTemporaryFile() as ntf:
             utils.init_model_vectorizer(ntf.name)

--- a/kepler/utils.py
+++ b/kepler/utils.py
@@ -264,7 +264,7 @@ def layer_architecture(model):
     return layer_config
 
 
-def model_representation(model, dv=None):
+def model_representation(model, dv):
     """Get a sparse vector representation of a model.
 
     Arguments:
@@ -280,8 +280,6 @@ def model_representation(model, dv=None):
             spec = yaml.load(model)
         model = layer_architecture(spec)
     layer_counts = count_layer_types(model)
-    if not dv:
-        dv = get_model_vectorizer()
     return dv.transform(layer_counts)
 
 

--- a/kepler/utils.py
+++ b/kepler/utils.py
@@ -14,7 +14,8 @@ from datetime import datetime
 
 from keras import layers as L
 from keras.engine.base_layer import Layer
-# from keras.engine.training import Model
+from keras.engine.training import Model
+from keras.models import Sequential
 from keras.utils.layer_utils import count_params as k_count_params
 import numpy as np
 from scipy.io import mmread, mmwrite
@@ -24,7 +25,7 @@ from sklearn.externals import joblib
 from sqlalchemy import create_engine
 import yaml
 
-from kepler.db_models import KeplerBase
+from kepler.db_models import KeplerBase, add_project
 
 
 def get_keras_layers():
@@ -46,7 +47,7 @@ def load_config(path=None):
         if not config_dir:
             config_dir = op.expanduser('~/.kepler')
         path = op.join(config_dir, 'config.ini')
-    config = ConfigParser()
+    config = ConfigParser(interpolation=ExtendedInterpolation())
     config.read(path)
     return config
 
@@ -61,18 +62,24 @@ def initdb(path):
         Destination path of the sqlite db.
     """
     if op.isdir(path):
-        path = op.join(path, 'kepler.db')
-    with sqlite3.connect(path) as conn:
+        dbpath = op.join(path, 'kepler.db')
+    else:
+        dbpath = path
+        path = op.dirname(path)
+    with sqlite3.connect(dbpath) as conn:
         cursor = conn.cursor()
         cursor.execute('''
         CREATE TABLE metadata(created timestamp, location text);
         ''')
         cursor.execute('''
         INSERT INTO metadata(created, location) values (?, ?)''',
-                       (datetime.now(), path))
+                       (datetime.now(), dbpath))
         conn.commit()
-    engine = get_engine(path)
+    engine = get_engine(dbpath)
     KeplerBase.metadata.create_all(engine)
+
+    # add the default project
+    add_project(engine, name='default', location=path, desc='Default project')
 
 
 def init_model_vectorizer(path=None):
@@ -447,3 +454,27 @@ def runs_test(x):
         (n_pos + n_neg) ** 2 / (n_pos + n_neg - 1)
     sr = np.sqrt(sr2)
     return (n_runs - rhat) / sr
+
+
+def name_keras_model(model):
+    """Name the keras model.
+
+    Parameters
+    ----------
+        model : keras.training.Model
+
+    Returns
+    -------
+    str
+        A made up name for the model
+
+    Example
+    -------
+
+    """
+    if isinstance(model, Sequential):
+        mtype = 'Sequential'
+    elif isinstance(model, Model):
+        mtype = 'FunctionalModel'
+    n_layers = count_layers(model)
+    return f'{mtype}-{n_layers}-layers'


### PR DESCRIPTION
Each model can be nested under a project. A project has a name, location
and a description. Projects can share models. A project named 'default'
is added by default. All models go to this project by default.